### PR TITLE
[EmployeeReadRepoImp] 구현 완료 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ out/
 !**/src/main/**/out/
 !**/src/test/**/out/
 
+Ignore.java
+
 ### Eclipse ###
 .apt_generated
 .classpath

--- a/managements_program.iml
+++ b/managements_program.iml
@@ -27,5 +27,6 @@
         <jarDirectory url="file://$MODULE_DIR$/libs" recursive="false" />
       </library>
     </orderEntry>
+    <orderEntry type="library" name="mysql-connector-java-8.0.17" level="project" />
   </component>
 </module>

--- a/src/employee/repository/EmployeeReadRepoImp.java
+++ b/src/employee/repository/EmployeeReadRepoImp.java
@@ -1,19 +1,88 @@
 package employee.repository;
 
 import employee.dto.EmployeeDto;
+import object.ObjectIo;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 
-public class EmployeeReadRepoImp implements EmployeeReadRepo{
 
+/**
+ *  DB에 저장된 Employee 정보를 가져오는 클래스
+ */
+public class EmployeeReadRepoImp implements EmployeeReadRepo {
 
+    Connection connection = ObjectIo.getConnection();
+    PreparedStatement pstmt = null;
+    ResultSet rs = null;
+
+    /**
+     * Employee 1명의 정보를 가져오는 메서드
+     * @param eno
+     * @return Employee
+     */
     @Override
     public EmployeeDto ReadOne(Integer eno) {
-        return null;
+
+        try {
+            String sql = new StringBuilder()
+                    .append("SELECT * FROM EMPLOYEE WHERE eno = ?").toString();
+            pstmt = connection.prepareStatement(sql);
+            pstmt.setInt(1, eno);
+            rs = pstmt.executeQuery();
+
+            EmployeeDto dto = new EmployeeDto();
+            dto.setEno(rs.getInt("eno"));
+            dto.setName(rs.getString("name"));
+            dto.setEnteryear(rs.getInt("enteryear"));
+            dto.setEntermonth(rs.getInt("entermonth"));
+            dto.setEnterday(rs.getInt("enterday"));
+            dto.setRole(rs.getString("role"));
+            dto.setSecno(rs.getInt("secno"));
+            dto.setSalary(rs.getInt("salary"));
+            pstmt.close();
+            return dto;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
+    /**
+     * Employee 전체 정보를 가져오는 메서드
+     * @return List<EmployeeDto>
+     */
     @Override
     public List<EmployeeDto> ReadAll() {
-        return null;
+        List<EmployeeDto> list = new ArrayList<>();
+
+        try {
+            String sql = new StringBuilder()
+                    .append("SELECT * FROM EMPLOYEE").toString();
+            pstmt = connection.prepareStatement(sql);
+            rs = pstmt.executeQuery();
+
+            while (rs.next()) {
+                EmployeeDto dto = new EmployeeDto();
+                dto.setEno(rs.getInt("eno"));
+                dto.setName(rs.getString("name"));
+                dto.setEnteryear(rs.getInt("enteryear"));
+                dto.setEntermonth(rs.getInt("entermonth"));
+                dto.setEnterday(rs.getInt("enterday"));
+                dto.setRole(rs.getString("role"));
+                dto.setSecno(rs.getInt("secno"));
+                dto.setSalary(rs.getInt("salary"));
+                list.add(dto);
+            }
+
+            return list;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+
     }
 }

--- a/src/object/ObjectIo.java
+++ b/src/object/ObjectIo.java
@@ -1,6 +1,10 @@
 package object;
 
+import common.Ignore;
+
 import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 
 public class ObjectIo { // 싱글톤
     private static ObjectIo objectIo = new ObjectIo();
@@ -9,10 +13,16 @@ public class ObjectIo { // 싱글톤
 
     public static ObjectIo getInstance(){
       return objectIo;
-    };
-
+    }
 
     public static Connection getConnection(){
-        return connection;// 구현;
+        Connection connection = null;
+        try {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            connection = DriverManager.getConnection(Ignore.URL.getMsg(),"Employee", Ignore.PASSWORD.getMsg());
+        }  catch (ClassNotFoundException | SQLException e) {
+            e.printStackTrace();
+        }
+        return connection;
     }
 }


### PR DESCRIPTION
DB에 저장된 Employee 정보를 가져오는 클래스 구현

리뷰 요청: 
ReadOne과 ReadAll 메서드에 
 EmployeeDto dto = new EmployeeDto();
            dto.setEno(rs.getInt("eno"));
            dto.setName(rs.getString("name"));
            dto.setEnteryear(rs.getInt("enteryear"));
            dto.setEntermonth(rs.getInt("entermonth"));
            dto.setEnterday(rs.getInt("enterday"));
            dto.setRole(rs.getString("role"));
            dto.setSecno(rs.getInt("secno"));
            dto.setSalary(rs.getInt("salary"));

해당 부분이 중복되는데 메서드로 빼는게 좋을까요?
