### PR TITLE
Feat/createcontrollermodify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,16 @@ dataSources.local.xml
 # 라이브러리 폴더 무시
 libs/
 *.jar
+
+# IntelliJ IDEA 설정 관련 파일 무시
+ .idea/
+ .idea/jdk.table.xml
+.idea/workspace.xml
+.idea/modules.xml
+.idea/shelf/
+.idea/gradle.xml
+
+
+-.idea/dataSources.xml
+-src/common/Ignore.java
+.gitignore

--- a/src/common/EmployeeText.java
+++ b/src/common/EmployeeText.java
@@ -36,7 +36,8 @@ public enum EmployeeText {
     EMPLOYEE_CREATE_SUCCESS("직원 정보 생성 성공!"),
     EMPLOYEE_CREATE_FAIL("직원 정보 생성 실패!"),
     PRINT_ROUND("-------------------------------------------------------------------------"),
-    PRINT_TITLE(String.format("%-5s %-10s %-12s %-14s %3s %8s","사번", "이름", "입사일", "직급", "부서번호", "임금"));
+    PRINT_TITLE(String.format("%-5s %-10s %-12s %-14s %3s %8s","사번", "이름", "입사일", "직급", "부서번호", "임금")),
+    INPUT_ROLE("1.Staff 2.Manager 3.Secretary\t\t(기본입력 : Staff)");
 
 
 

--- a/src/employee/controller/EmployeeCreateContImp.java
+++ b/src/employee/controller/EmployeeCreateContImp.java
@@ -51,7 +51,16 @@ public class EmployeeCreateContImp implements EmployeeCreateCont {
         System.out.printf(ENTER_ENTRY_DAY.getText());
         employeeDto.setEnterday(inputNum());
         System.out.printf(ENTER_ROLE.getText());
-        employeeDto.setRole(in.nextLine());
+        System.out.println(INPUT_ROLE.getText());
+        System.out.println(ENTER_CHOICE.getText());
+        String roleinput = null;
+        switch (inputNum()){
+            case 1 -> roleinput = "Staff";
+            case 2 -> roleinput = "Manager";
+            case 3 -> roleinput = "Secretary";
+            default -> roleinput = "Staff";
+        }
+        employeeDto.setRole(roleinput);
         System.out.printf(ENTER_SECTION_NUMBER.getText());
         employeeDto.setSecno(inputNum());
         System.out.printf(ENTER_SALARY.getText());


### PR DESCRIPTION
직원 생성 로직 일부 변경하였습니다.

기존 Role입력방법은 staff,manger,Secretary 직접 입력을 하였는데,

이렇게 입력시 급여 인상 메소드 실행시 대소문자가 일치하지않으면 인상을 못하는 현상을 발견하였습니다.

Switch이용하여 선택하여 문자를 넣어주면 해당 문제가 사라져서 변경하였습니다.